### PR TITLE
add missing «trouble» local part to RFC 2142 section

### DIFF
--- a/list.yml
+++ b/list.yml
@@ -19,6 +19,7 @@
     - abuse
     - noc
     - security
+    - trouble
     - postmaster
     - hostmaster
     - usenet


### PR DESCRIPTION
Hi Marco,

Mainly just wanted to say thanks for putting this together, really appreciate it 👌🏼

RFC 2142 mentions «TROUBLE» mailbox as a de-facto mailbox [here](https://datatracker.ietf.org/doc/html/rfc2142#section-1) but surprisingly doesn't mention it together with other mailboxes in [section 4](https://datatracker.ietf.org/doc/html/rfc2142#section-4).

Just wanted to let you know 😊 thanks again so much for this 🙏🏼